### PR TITLE
预览图片 可设置从第几张开始

### DIFF
--- a/easyPhotos/src/main/java/com/huantansheng/easyphotos/EasyPhotos.java
+++ b/easyPhotos/src/main/java/com/huantansheng/easyphotos/EasyPhotos.java
@@ -222,8 +222,7 @@ public class EasyPhotos {
      * @param bottomPreview 是否显示底部预览效果
      */
     public static void startPreviewPhotos(FragmentActivity act, @NonNull ImageEngine imageEngine, @NonNull ArrayList<Photo> photos, boolean bottomPreview) {
-        Setting.imageEngine = imageEngine;
-        PreviewActivity.start(act, photos, bottomPreview);
+        EasyPhotos.startPreviewPhotos(act, imageEngine, photos, bottomPreview, 0);
     }
 
     /**
@@ -235,15 +234,47 @@ public class EasyPhotos {
      * @param bottomPreview 是否显示底部预览效果
      */
     public static void startPreviewPaths(FragmentActivity act, @NonNull ImageEngine imageEngine, @NonNull ArrayList<String> paths, boolean bottomPreview) {
-        Setting.imageEngine = imageEngine;
         ArrayList<Photo> photos = new ArrayList<>();
         for (String path : paths) {
             Photo photo = new Photo(null, path, 0, 0, 0, 0, 0, "");
             photos.add(photo);
         }
-        PreviewActivity.start(act, photos, bottomPreview);
+        EasyPhotos.startPreviewPhotos(act, imageEngine, photos, bottomPreview, 0);
     }
 
+
+
+    /**
+     * 提供外部预览图片（网络图片请开启网络权限）
+     *
+     * @param act           上下文
+     * @param imageEngine   图片加载引擎
+     * @param paths         图片路径集合
+     * @param bottomPreview 是否显示底部预览效果
+     * @param currIndex     预览图片从第几张开始
+     */
+    public static void startPreviewPaths(FragmentActivity act, @NonNull ImageEngine imageEngine, @NonNull ArrayList<String> paths, boolean bottomPreview, int currIndex) {
+        ArrayList<Photo> photos = new ArrayList<>();
+        for (String path : paths) {
+            Photo photo = new Photo(null, path, 0, 0, 0, 0, 0, "");
+            photos.add(photo);
+        }
+        EasyPhotos.startPreviewPhotos(act, imageEngine, photos, bottomPreview, currIndex);
+    }
+
+    /**
+     * 提供外部预览图片（网络图片请开启网络权限）
+     *
+     * @param act           上下文
+     * @param imageEngine   图片加载引擎
+     * @param photos        图片Photo集合
+     * @param bottomPreview 是否显示底部预览效果
+     * @param currIndex     预览图片从第几张开始
+     */
+    public static void startPreviewPhotos(FragmentActivity act, @NonNull ImageEngine imageEngine, @NonNull ArrayList<Photo> photos, boolean bottomPreview, int currIndex) {
+        Setting.imageEngine = imageEngine;
+        PreviewActivity.start(act, photos, bottomPreview, currIndex);
+    }
     //**************更新媒体库***********************
 
     /**

--- a/easyPhotos/src/main/java/com/huantansheng/easyphotos/ui/PreviewActivity.java
+++ b/easyPhotos/src/main/java/com/huantansheng/easyphotos/ui/PreviewActivity.java
@@ -55,12 +55,19 @@ public class PreviewActivity extends AppCompatActivity implements PreviewPhotosA
     }
 
     public static void start(Activity act, ArrayList<Photo> photos, boolean bottomPreview) {
+        PreviewActivity.start(act,photos,bottomPreview,0);
+    }
+
+    public static void start(Activity act, ArrayList<Photo> photos, boolean bottomPreview, int currIndex) {
+        if (photos != null && photos.size() < 1) return;
+        if (currIndex < 0) currIndex = 0;
+        if (currIndex > photos.size()-1) currIndex = photos.size()-1;
         Intent intent = new Intent(act, PreviewActivity.class);
         intent.putExtra(Key.PREVIEW_EXTERNAL_PHOTOS, photos);
         intent.putExtra(Key.PREVIEW_EXTERNAL_PHOTOS_BOTTOM_PREVIEW, bottomPreview);
+        intent.putExtra(Key.PREVIEW_PHOTO_INDEX, currIndex);
         act.startActivity(intent);
     }
-
 
     /**
      * 一些旧设备在UI小部件更新之间需要一个小延迟


### PR DESCRIPTION
场景：点击多张图片缩略图的每一张图片，进入预览图片（调用方法startPreviewPhotos或者startPreviewPaths）。有很需求期望是进入到预览图片之后，最开始展现的用户点击的那张。
todo：解决这一场景，我查看了源代码。发现PreviewActivity中已存在可支持传入“Key.PREVIEW_PHOTO_INDEX”来控制预览图片从第几张开始（👍）。我稍微做了下处理。